### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -7,13 +7,13 @@ jobs:
     name: Test PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: ".python-version"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.8.23"
       - name: Run tests

--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -16,13 +16,13 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version-file: ".python-version"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.8.23"
       - name: Run tests


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6
- Bump `actions/setup-python` v5 → v6
- Bump `astral-sh/setup-uv` v6 → v7

All three updated versions use Node.js 24, resolving the deprecation warning. Node.js 20 actions will be forced to run on Node.js 24 starting June 2, 2026.

## Test plan
- [x] Verify PR test workflow passes with updated action versions
- [ ] Verify publish workflow syntax is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)