### PR TITLE
Add official OAuth and HijuConn appliance fallbacks for bapi failures

### DIFF
--- a/connectlife/api.py
+++ b/connectlife/api.py
@@ -24,6 +24,7 @@ GATEWAY_FALLBACK_STATUSES = frozenset({500, 502, 503, 504})
 AUTH_TRANSIENT_STATUSES = frozenset({500, 502, 503, 504})
 
 BAPI_USER_AGENT = "connectlife-api-connector 2.1.4"
+DEFAULT_OAUTH_REDIRECT_URI = "https://api.connectlife.io/swagger/oauth2-redirect.html"
 
 GATEWAY_USER_AGENT = "Runner/2.0.6 (iPhone; iOS 17.2.1; Scale/3.00)"
 GATEWAY_BASE_URL = "https://clife-eu-gateway.hijuconn.com"
@@ -85,13 +86,13 @@ LEGACY_OAUTH_PROFILE = OAuthClientProfile(
     name="legacy",
     client_id="5065059336212",
     client_secret="07swfKgvJhC3ydOUS9YV_SwVz0i4LKqlOLGNUukYHVMsJRF1b-iWeUGcNlXyYCeK",
-    redirect_uri="https://api.connectlife.io/swagger/oauth2-redirect.html",
+    redirect_uri=DEFAULT_OAUTH_REDIRECT_URI,
 )
 OFFICIAL_OAUTH_PROFILE = OAuthClientProfile(
     name="official",
     client_id="9793620883275788",
     client_secret="7h1m3gZVlILyBvIFBNmzXwoFYLhkGqG9NQd2jBzuZCqJKCTyCtYwQtXi4tVBjg9B",
-    redirect_uri="http://homeassistant.local:8123/auth/external/callback",
+    redirect_uri=DEFAULT_OAUTH_REDIRECT_URI,
 )
 
 
@@ -99,29 +100,33 @@ class ConnectLifeApi:
     """ConnectLife API client."""
 
     api_key = "4_yhTWQmHFpZkQZDSV1uV-_A"
-    client_id = LEGACY_OAUTH_PROFILE.client_id
-    client_secret = LEGACY_OAUTH_PROFILE.client_secret
 
     login_url = "https://accounts.eu1.gigya.com/accounts.login"
     jwt_url = "https://accounts.eu1.gigya.com/accounts.getJWT"
 
-    oauth2_redirect = LEGACY_OAUTH_PROFILE.redirect_uri
     oauth2_authorize = "https://oauth.hijuconn.com/oauth/authorize"
     oauth2_token = "https://oauth.hijuconn.com/oauth/token"
 
     appliances_url = "https://connectlife.bapi.ovh/appliances"
     request_timeout = aiohttp.ClientTimeout(total=30)
 
-    def __init__(self, username: str, password: str, test_server: str | None = None):
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        test_server: str | None = None,
+        oauth_redirect_uri: str | None = None,
+    ):
         """Initialize the client."""
+        redirect_uri = oauth_redirect_uri or DEFAULT_OAUTH_REDIRECT_URI
         self._oauth_profiles: tuple[OAuthClientProfile, ...] = (
-            LEGACY_OAUTH_PROFILE,
-            OFFICIAL_OAUTH_PROFILE,
+            LEGACY_OAUTH_PROFILE._replace(redirect_uri=redirect_uri),
+            OFFICIAL_OAUTH_PROFILE._replace(redirect_uri=redirect_uri),
         )
         if test_server:
             self.login_url = f"{test_server}/accounts.login"
             self.jwt_url = f"{test_server}/accounts.getJWT"
-            self.oauth2_redirect = f"{test_server}/swagger/oauth2-redirect.html"
+            redirect_uri = f"{test_server}/swagger/oauth2-redirect.html"
             self.oauth2_authorize = f"{test_server}/oauth/authorize"
             self.oauth2_token = f"{test_server}/oauth/token"
             self.appliances_url = f"{test_server}/appliances"
@@ -130,7 +135,7 @@ class ConnectLifeApi:
                     name="test-server",
                     client_id=LEGACY_OAUTH_PROFILE.client_id,
                     client_secret=LEGACY_OAUTH_PROFILE.client_secret,
-                    redirect_uri=self.oauth2_redirect,
+                    redirect_uri=redirect_uri,
                 ),
             )
 
@@ -237,7 +242,6 @@ class ConnectLifeApi:
             GATEWAY_DEVICE_LIST_URL,
             payload={},
             retry_on_reauth=retry_on_reauth,
-            method="GET",
         )
         device_list = gateway_response.get("deviceList")
         if not isinstance(device_list, list):
@@ -309,6 +313,7 @@ class ConnectLifeApi:
                     return
                 except (aiohttp.ClientError, TimeoutError) as err:
                     last_error = LifeConnectAuthError(f"Unexpected error during login: {err}")
+                    last_error.__cause__ = err
                     if attempt == attempts:
                         break
                     _LOGGER.warning(
@@ -507,24 +512,15 @@ class ConnectLifeApi:
         *,
         payload: dict[str, Any],
         retry_on_reauth: bool,
-        method: str = "POST",
     ) -> dict[str, Any]:
         request_data = self._gateway_request_data(payload)
 
         async with self._client_session() as session:
-            request = session.get if method == "GET" else session.post
-            request_kwargs: dict[str, Any]
-            if method == "GET":
-                request_kwargs = {
-                    "params": request_data,
-                    "headers": {"User-Agent": GATEWAY_USER_AGENT},
-                }
-            else:
-                request_kwargs = {
-                    "json": request_data,
-                    "headers": {"User-Agent": GATEWAY_USER_AGENT},
-                }
-            async with request(url, **request_kwargs) as response:
+            async with session.post(
+                url,
+                json=request_data,
+                headers={"User-Agent": GATEWAY_USER_AGENT},
+            ) as response:
                 if response.status != 200:
                     body = await self._read_response_body(response)
                     raise self._response_error(
@@ -555,7 +551,6 @@ class ConnectLifeApi:
                 url,
                 payload=payload,
                 retry_on_reauth=False,
-                method=method,
             )
 
         error_type = LifeConnectAuthError if error_code == GATEWAY_INVALID_ACCESS_TOKEN else LifeConnectError

--- a/connectlife/tests/test_api.py
+++ b/connectlife/tests/test_api.py
@@ -14,6 +14,7 @@ from connectlife import api as api_module
 from connectlife.api import (
     BAPI_APPLIANCES_TIMEOUT,
     ConnectLifeApi,
+    DEFAULT_OAUTH_REDIRECT_URI,
     GATEWAY_DEVICE_LIST_URL,
     GATEWAY_UPDATE_URL,
     LEGACY_OAUTH_PROFILE,
@@ -254,14 +255,59 @@ class TestLoginRetry(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(api._access_token, "official-access-token")
         self.assertEqual(api._refresh_token, "official-refresh-token")
         self.assertEqual(authorize_payloads[0]["client_id"], LEGACY_OAUTH_PROFILE.client_id)
-        self.assertEqual(authorize_payloads[0]["redirect_uri"], LEGACY_OAUTH_PROFILE.redirect_uri)
+        self.assertEqual(authorize_payloads[0]["redirect_uri"], DEFAULT_OAUTH_REDIRECT_URI)
         self.assertEqual(authorize_payloads[1]["client_id"], LEGACY_OAUTH_PROFILE.client_id)
-        self.assertEqual(authorize_payloads[1]["redirect_uri"], LEGACY_OAUTH_PROFILE.redirect_uri)
+        self.assertEqual(authorize_payloads[1]["redirect_uri"], DEFAULT_OAUTH_REDIRECT_URI)
         self.assertEqual(authorize_payloads[2]["client_id"], OFFICIAL_OAUTH_PROFILE.client_id)
-        self.assertEqual(authorize_payloads[2]["redirect_uri"], OFFICIAL_OAUTH_PROFILE.redirect_uri)
+        self.assertEqual(authorize_payloads[2]["redirect_uri"], DEFAULT_OAUTH_REDIRECT_URI)
         self.assertEqual(token_payloads[0]["client_id"], OFFICIAL_OAUTH_PROFILE.client_id)
         self.assertEqual(token_payloads[0]["client_secret"], OFFICIAL_OAUTH_PROFILE.client_secret)
         self.assertFalse(requests)
+
+    async def test_login_uses_custom_redirect_uri_when_provided(self) -> None:
+        api = ConnectLifeApi(
+            "user@example.com",
+            "secret",
+            oauth_redirect_uri="https://example.com/oauth/callback",
+        )
+
+        requests: list[tuple[str, str, FakeResponse | Exception]] = [
+            (
+                "POST",
+                api.login_url,
+                FakeResponse(200, {"UID": "uid-1", "sessionInfo": {"cookieValue": "login-token"}}),
+            ),
+            ("POST", api.jwt_url, FakeResponse(200, {"id_token": "jwt-token"})),
+            ("POST", api.oauth2_authorize, FakeResponse(200, {"code": "auth-code"})),
+            (
+                "POST",
+                api.oauth2_token,
+                FakeResponse(200, {
+                    "access_token": "custom-access-token",
+                    "expires_in": 3600,
+                    "refresh_token": "custom-refresh-token",
+                }),
+            ),
+        ]
+
+        authorize_payloads: list[dict[str, Any]] = []
+        token_payloads: list[dict[str, Any]] = []
+
+        def record_post(self: FakeSession, url: str, **kwargs: Any) -> FakeResponse:
+            if url == api.oauth2_authorize and "json" in kwargs:
+                authorize_payloads.append(kwargs["json"])
+            if url == api.oauth2_token and "data" in kwargs:
+                token_payloads.append(kwargs["data"])
+            return FakeSession._next(self, "POST", url)
+
+        with (
+            patch.object(api_module.aiohttp, "ClientSession", new=FakeClientSessionFactory(requests)),
+            patch.object(FakeSession, "post", new=record_post),
+        ):
+            await api.login()
+
+        self.assertEqual(authorize_payloads[0]["redirect_uri"], "https://example.com/oauth/callback")
+        self.assertEqual(token_payloads[0]["redirect_uri"], "https://example.com/oauth/callback")
 
 
 class TestAppliancesReauth(unittest.IsolatedAsyncioTestCase):
@@ -295,7 +341,7 @@ class TestAppliancesReauth(unittest.IsolatedAsyncioTestCase):
             *_successful_login_requests(api, access_token="replacement-access-token", refresh_token="replacement-refresh-token"),
             ("GET", api.appliances_url, FakeResponse(500, {"error": "backend unavailable"})),
             (
-                "GET",
+                "POST",
                 GATEWAY_DEVICE_LIST_URL,
                 FakeResponse(200, {"response": {"resultCode": 0, "deviceList": [{"deviceId": "device-1"}]}}),
             ),
@@ -316,7 +362,7 @@ class TestAppliancesReauth(unittest.IsolatedAsyncioTestCase):
         requests: list[tuple[str, str, FakeResponse | Exception]] = [
             ("GET", api.appliances_url, TimeoutError()),
             (
-                "GET",
+                "POST",
                 GATEWAY_DEVICE_LIST_URL,
                 FakeResponse(200, {"response": {"resultCode": 0, "deviceList": [{"deviceId": "device-1"}]}}),
             ),
@@ -505,6 +551,7 @@ class TestTransportErrorRetry(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(LifeConnectAuthError) as ctx:
                 await api.login()
             self.assertIn("connection refused", str(ctx.exception))
+            self.assertIsInstance(ctx.exception.__cause__, aiohttp.ClientConnectionError)
 
 
 class TestAuthenticate(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- add a secondary OAuth client profile using the official ConnectLife app credentials when the legacy OAuth client fails with transient or transport errors
- shorten appliance-list `bapi` reads to a dedicated 10 second timeout so callers can recover instead of stalling on the full session timeout
- fall back to the HijuConn gateway device-list endpoint when `https://connectlife.bapi.ovh/appliances` returns retryable failures or times out
- keep non-transient authentication errors immediate so bad credentials still fail fast instead of cycling through alternate clients
- extend the test suite to cover the official OAuth fallback, gateway appliance fallback after `bapi` 5xx responses, gateway fallback after timeouts, and the shorter appliance timeout guardrail

## Why
Some accounts are currently able to authenticate successfully but still hit repeated `500` responses or timeouts from the `bapi` appliance endpoint. In those cases the library fails the refresh even though the HijuConn gateway can still return device status data.

This change keeps the existing `bapi` appliance path as the primary read path, but makes the client more resilient when that endpoint is flaky:
- transient auth/client issues can retry with the official OAuth client profile
- appliance reads can recover through the gateway status endpoint instead of surfacing a hard failure

## Testing
- `.venv/bin/python -m unittest discover -s connectlife/tests -p 'test*.py'`
- `.venv/bin/python -m compileall connectlife`
