### PR TITLE
Version 0.6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectlife"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     { name="Øyvind Matheson Wergeland", email="oyvind@wergeland.org" },
 ]


### PR DESCRIPTION
## Summary
- Bugfix release 0.6.1
- Includes official OAuth and HijuConn appliance fallbacks for bapi failures (#47)
- Updates GitHub Actions to Node.js 24 versions (#46)

## Test plan
- [x] Verify CI passes
- [ ] Tag `v0.6.1` after merge to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)