### PR TITLE
Use GET for HijuConn device list fallback

### DIFF
--- a/connectlife/api.py
+++ b/connectlife/api.py
@@ -242,6 +242,7 @@ class ConnectLifeApi:
             GATEWAY_DEVICE_LIST_URL,
             payload={},
             retry_on_reauth=retry_on_reauth,
+            method="GET",
         )
         device_list = gateway_response.get("deviceList")
         if not isinstance(device_list, list):
@@ -512,15 +513,24 @@ class ConnectLifeApi:
         *,
         payload: dict[str, Any],
         retry_on_reauth: bool,
+        method: str = "POST",
     ) -> dict[str, Any]:
         request_data = self._gateway_request_data(payload)
 
         async with self._client_session() as session:
-            async with session.post(
-                url,
-                json=request_data,
-                headers={"User-Agent": GATEWAY_USER_AGENT},
-            ) as response:
+            request = session.get if method == "GET" else session.post
+            request_kwargs: dict[str, Any]
+            if method == "GET":
+                request_kwargs = {
+                    "params": request_data,
+                    "headers": {"User-Agent": GATEWAY_USER_AGENT},
+                }
+            else:
+                request_kwargs = {
+                    "json": request_data,
+                    "headers": {"User-Agent": GATEWAY_USER_AGENT},
+                }
+            async with request(url, **request_kwargs) as response:
                 if response.status != 200:
                     body = await self._read_response_body(response)
                     raise self._response_error(
@@ -551,6 +561,7 @@ class ConnectLifeApi:
                 url,
                 payload=payload,
                 retry_on_reauth=False,
+                method=method,
             )
 
         error_type = LifeConnectAuthError if error_code == GATEWAY_INVALID_ACCESS_TOKEN else LifeConnectError

--- a/connectlife/tests/test_api.py
+++ b/connectlife/tests/test_api.py
@@ -341,7 +341,7 @@ class TestAppliancesReauth(unittest.IsolatedAsyncioTestCase):
             *_successful_login_requests(api, access_token="replacement-access-token", refresh_token="replacement-refresh-token"),
             ("GET", api.appliances_url, FakeResponse(500, {"error": "backend unavailable"})),
             (
-                "POST",
+                "GET",
                 GATEWAY_DEVICE_LIST_URL,
                 FakeResponse(200, {"response": {"resultCode": 0, "deviceList": [{"deviceId": "device-1"}]}}),
             ),
@@ -362,7 +362,27 @@ class TestAppliancesReauth(unittest.IsolatedAsyncioTestCase):
         requests: list[tuple[str, str, FakeResponse | Exception]] = [
             ("GET", api.appliances_url, TimeoutError()),
             (
-                "POST",
+                "GET",
+                GATEWAY_DEVICE_LIST_URL,
+                FakeResponse(200, {"response": {"resultCode": 0, "deviceList": [{"deviceId": "device-1"}]}}),
+            ),
+        ]
+
+        with patch.object(api_module.aiohttp, "ClientSession", new=FakeClientSessionFactory(requests)):
+            result = await api.get_appliances_json()
+
+        self.assertEqual(result, [{"deviceId": "device-1"}])
+        self.assertFalse(requests)
+
+    async def test_appliance_list_gateway_fallback_uses_get(self) -> None:
+        api = ConnectLifeApi("user@example.com", "secret")
+        api._access_token = "cached-access-token"
+        api._expires = dt.datetime.now() + dt.timedelta(minutes=5)
+
+        requests: list[tuple[str, str, FakeResponse | Exception]] = [
+            ("GET", api.appliances_url, TimeoutError()),
+            (
+                "GET",
                 GATEWAY_DEVICE_LIST_URL,
                 FakeResponse(200, {"response": {"resultCode": 0, "deviceList": [{"deviceId": "device-1"}]}}),
             ),


### PR DESCRIPTION
## Summary
- restore GET for the HijuConn appliance list fallback endpoint
- keep POST for gateway write operations
- add a regression test that locks gateway appliance list fallback to GET

## Why
The regression came from the earlier review-driven change that switched `clife-svc/pu/get_device_status_list` from GET to POST.

That endpoint does not behave like the gateway write endpoints:
- appliance listing works with GET
- appliance listing fails with POST
- gateway writes still use POST

I verified this live against a real account/device while investigating the Home Assistant failure:
- GET to `clife-svc/pu/get_device_status_list` returned `resultCode: 0` with a valid `deviceList`
- POST to the same endpoint returned `errorCode: 101005` with `randStr check fail.`

So the breakage was caused specifically by the GET-to-POST change for the appliance-list fallback path. The other review follow-up changes in #47, like preserving `__cause__` and making the redirect URI configurable/library-neutral, were not the cause of this regression.

## Testing
- `.venv/bin/python -m unittest discover -s connectlife/tests -p 'test*.py'`
- `.venv/bin/python -m compileall connectlife`
