### PR TITLE
fix: Raise LifeConnectError for transport failures during login

### DIFF
--- a/connectlife/api.py
+++ b/connectlife/api.py
@@ -126,7 +126,7 @@ class ConnectLifeApi:
         """Test whether the full ConnectLife login flow succeeds."""
         try:
             await self.login()
-        except LifeConnectAuthError:
+        except LifeConnectError:
             return False
         return True
 
@@ -271,14 +271,14 @@ class ConnectLifeApi:
 
     async def _initial_access_token_with_retry(self) -> None:
         attempts = 2
-        last_error: LifeConnectAuthError | None = None
+        last_error: LifeConnectError | None = None
 
         for attempt in range(1, attempts + 1):
             try:
                 await self._initial_access_token()
                 return
             except (aiohttp.ClientError, TimeoutError) as err:
-                last_error = LifeConnectAuthError(f"Unexpected error during login: {err}")
+                last_error = LifeConnectError(f"Unexpected error during login: {err}")
                 last_error.__cause__ = err
                 if attempt == attempts:
                     break
@@ -305,7 +305,7 @@ class ConnectLifeApi:
 
         if last_error is not None:
             raise last_error
-        raise LifeConnectAuthError("Unexpected error during login")
+        raise LifeConnectError("Unexpected error during login")
 
     async def _initial_access_token(self) -> None:
         async with self._client_session() as session:

--- a/connectlife/tests/test_api.py
+++ b/connectlife/tests/test_api.py
@@ -755,8 +755,9 @@ class TestTransportErrorRetry(unittest.IsolatedAsyncioTestCase):
             patch.object(api, "_initial_access_token", side_effect=always_fail),
             patch.object(api_module.asyncio, "sleep", return_value=None),
         ):
-            with self.assertRaises(LifeConnectAuthError) as ctx:
+            with self.assertRaises(LifeConnectError) as ctx:
                 await api.login()
+            self.assertNotIsInstance(ctx.exception, LifeConnectAuthError)
             self.assertIn("connection refused", str(ctx.exception))
             self.assertIsInstance(ctx.exception.__cause__, aiohttp.ClientConnectionError)
 


### PR DESCRIPTION
## Summary

- Transport errors (DNS failures, timeouts, connection resets) during the OAuth login flow were incorrectly wrapped as `LifeConnectAuthError`, causing downstream consumers (e.g. the HA integration coordinator) to treat transient connectivity issues as permanent authentication failures — disabling polling until manually reloaded.
- `_initial_access_token_with_retry` now raises `LifeConnectError` for transport errors, reserving `LifeConnectAuthError` for genuine credential/auth failures.
- `authenticate()` now catches the base `LifeConnectError` so it still returns `False` on any login failure.

Fixes #60

## Test plan
- [x] All tests passing (37/37)
- [ ] Verify in HA that DNS blips during token refresh no longer permanently disable the integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)