### PR TITLE
Bump version to 0.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectlife"
-version = "0.7.1"
+version = "0.7.2"
 authors = [
     { name="Øyvind Matheson Wergeland", email="oyvind@wergeland.org" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "connectlife"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

- Bump version to 0.7.2 for PyPI release
- Includes fix from #61: transport errors during login now raise `LifeConnectError` instead of `LifeConnectAuthError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)