### PR TITLE
Add --auth_error_type option to test server

### DIFF
--- a/connectlife/test_server.py
+++ b/connectlife/test_server.py
@@ -11,12 +11,26 @@ appliances = {}
 failure_rate = 0
 timeout_rate = 0
 auth_error_rate = 0
+auth_error_type = "invalid_login"
+
+LOGIN_ERRORS = {
+    "invalid_login": {
+        "errorCode": 403042,
+        "errorMessage": "Invalid LoginID",
+        "errorDetails": "invalid loginID or password",
+    },
+    "pending_registration": {
+        "errorCode": 206001,
+        "errorMessage": "Account Pending Registration",
+        "errorDetails": "Missing required fields for registration: preferences.terms.connectlife_terms_conditions.isConsentGranted, preferences.privacy.connectlife_privacy_policy.isConsentGranted",
+    },
+}
 
 async def login(request):  # noqa: ARG001
     if auth_error_rate > randrange(100):
         return web.Response(
             content_type="application/json",
-            text='{"errorCode": 403042, "errorMessage": "Invalid LoginID", "errorDetails": "invalid loginID or password"}'
+            text=json.dumps(LOGIN_ERRORS[auth_error_type]),
         )
     return web.Response(
         content_type="application/json",
@@ -114,10 +128,12 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='ConnectLife API test server')
     parser.add_argument('-p', '--port', type=int, default=8080, help='Port on which to serve the web app')
     parser.add_argument('-a', '--auth_error_rate', type=int, default=0, help='Auth error rate in %% for login')
+    parser.add_argument('--auth_error_type', choices=list(LOGIN_ERRORS.keys()), default='invalid_login', help='Type of auth error to simulate')
     parser.add_argument('-f', '--failure_rate', type=int, default=0, help='Failure rate in %% for get appliances')
     parser.add_argument('-t', '--timeout_rate', type=int, default=0, help='Timeout rate in %% for get appliances')
     args = parser.parse_args()
     auth_error_rate = args.auth_error_rate
+    auth_error_type = args.auth_error_type
     failure_rate = args.failure_rate
     timeout_rate = args.timeout_rate
     main(args)


### PR DESCRIPTION
## Summary
- Adds `--auth_error_type` CLI flag to select which auth error response the test server returns
- Supports `invalid_login` (existing behavior, default) and `pending_registration` (new) error shapes
- Refactors the hardcoded error JSON into a `LOGIN_ERRORS` dict keyed by error type

## Test plan
- [x] Run `python -m connectlife.test_server -a 100` and confirm the default invalid_login response is returned
- [x] Run `python -m connectlife.test_server -a 100 --auth_error_type pending_registration` and confirm the pending-registration response is returned
- [x] Run `python -m connectlife.test_server --auth_error_type bogus` and confirm argparse rejects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)