### PR TITLE
Add TRIR (Russia/CIS) backend

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,8 @@ uv sync
 
 ## Test server
 
-Test server that mocks the ConnectLife API. Runs on `http://localhost:8080`.
+Test server that emulates the ConnectLife API, both normal and TRIR variants at the same time.
+Runs on `http://localhost:8080`.
 
 The server reads all JSON files in the current directory, and serves them as appliances. Properties can be updated,
 but is not persisted. The only validation is that the `puid` and `property` exists, it assumes that all properties

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ there is no guarantee that you don't experience other problems, for instance loc
 
 Licensed under [GPLv3](LICENSE).
 
-To test out the library:
+To test out the library (users in Russia/CIS may need to pass the `--trir` option):
 ```bash
 pip install connectlife
-python -m connectlife.dump --username <username> --password <password>
+python -m connectlife.dump --username <username> --password <password> [--trir]
 ```
 
-This will log in to the ConnectLife API using the provided username and password, and print the list of all fields
-for all appliances that is registered with the account.
+This will log in to the ConnectLife API using the provided username and password, and write a JSON
+file with all returned fields for each appliance that is registered with the account.
 
 The Home Assistant integration is currently in discovery phase. Please contribute your device dumps to help
 the development.

--- a/connectlife/api.py
+++ b/connectlife/api.py
@@ -97,6 +97,12 @@ class ConnectLifeApi:
     gateway_update_url = GATEWAY_UPDATE_URL
     gateway_energy_url = GATEWAY_ENERGY_URL
 
+    # Overridable so alternative backends (e.g. TRIR) can vary the client
+    # identity and the gateway error codes they react to.
+    gateway_user_agent = GATEWAY_USER_AGENT
+    invalid_access_token_code = GATEWAY_INVALID_ACCESS_TOKEN
+    randstr_check_failed_code = GATEWAY_RANDSTR_CHECK_FAILED
+
     def __init__(
         self,
         username: str,
@@ -481,12 +487,12 @@ class ConnectLifeApi:
             if method == "GET":
                 request_kwargs = {
                     "params": request_data,
-                    "headers": {"User-Agent": GATEWAY_USER_AGENT},
+                    "headers": {"User-Agent": self.gateway_user_agent},
                 }
             else:
                 request_kwargs = {
                     "json": request_data,
-                    "headers": {"User-Agent": GATEWAY_USER_AGENT},
+                    "headers": {"User-Agent": self.gateway_user_agent},
                 }
             async with request(url, **request_kwargs) as response:
                 if response.status != 200:
@@ -512,7 +518,7 @@ class ConnectLifeApi:
 
         error_code = gateway_response.get("errorCode")
         error_desc = gateway_response.get("errorDesc") or "Unknown gateway error"
-        if retry_on_reauth and error_code == GATEWAY_INVALID_ACCESS_TOKEN:
+        if retry_on_reauth and error_code == self.invalid_access_token_code:
             _LOGGER.warning("HijuConn gateway access token rejected, retrying full login")
             await self.login()
             return await self._request_gateway_json(
@@ -523,7 +529,7 @@ class ConnectLifeApi:
                 method=method,
             )
 
-        if retry_on_randstr and error_code == GATEWAY_RANDSTR_CHECK_FAILED:
+        if retry_on_randstr and error_code == self.randstr_check_failed_code:
             _LOGGER.warning("HijuConn gateway randStr check failed, retrying with fresh signature")
             return await self._request_gateway_json(
                 url,
@@ -533,7 +539,7 @@ class ConnectLifeApi:
                 method=method,
             )
 
-        error_type = LifeConnectAuthError if error_code == GATEWAY_INVALID_ACCESS_TOKEN else LifeConnectError
+        error_type = LifeConnectAuthError if error_code == self.invalid_access_token_code else LifeConnectError
         raise error_type(
             f"Unexpected response from HijuConn gateway: code={error_code} description='{error_desc}'",
             endpoint=url,

--- a/connectlife/dump.py
+++ b/connectlife/dump.py
@@ -6,6 +6,7 @@ import json
 import sys
 
 from .api import ConnectLifeApi
+from .trir import TrirConnectLifeApi
 
 
 def order_dict(dictionary):
@@ -13,8 +14,15 @@ def order_dict(dictionary):
             for k, v in sorted(dictionary.items())}
 
 
-async def main(username: str, password: str, format: str):
-    api = ConnectLifeApi(username, password)
+def build_api(username: str, password: str, trir: bool, device_uuid: str | None, platform: str):
+    if trir:
+        return TrirConnectLifeApi(
+            username, password, device_uuid=device_uuid, platform=platform
+        )
+    return ConnectLifeApi(username, password)
+
+
+async def main(api: ConnectLifeApi, format: str):
     appliances = await api.get_appliances_json()
     # Redact private fields
     for appliance in appliances:
@@ -51,6 +59,22 @@ if __name__ == "__main__":
         },
         default="json"
     )
+    parser.add_argument(
+        "-t",
+        "--trir",
+        action="store_true",
+        help="Use the TRIR (Russia/CIS) backend instead of the default",
+    )
+    parser.add_argument(
+        "--device-uuid",
+        help="TRIR only: stable device UUID (generated if omitted)",
+    )
+    parser.add_argument(
+        "--platform",
+        choices=["android", "ios"],
+        default="android",
+        help="TRIR only: app platform to emulate (default: android)",
+    )
     parser.add_argument("-v", "--verbose", action='store_true')
     args = parser.parse_args()
     username = args.username if args.username else input("Username: ")
@@ -64,4 +88,5 @@ if __name__ == "__main__":
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-    asyncio.run(main(username, password, args.format))
+    api = build_api(username, password, args.trir, args.device_uuid, args.platform)
+    asyncio.run(main(api, args.format))

--- a/connectlife/dump.py
+++ b/connectlife/dump.py
@@ -14,12 +14,15 @@ def order_dict(dictionary):
             for k, v in sorted(dictionary.items())}
 
 
-def build_api(username: str, password: str, trir: bool, device_uuid: str | None, platform: str):
+def build_api(username: str, password: str, trir: bool):
     if trir:
-        return TrirConnectLifeApi(
-            username, password, device_uuid=device_uuid, platform=platform
-        )
+        return TrirConnectLifeApi(username, password)
     return ConnectLifeApi(username, password)
+
+
+def feature_code(appliance: dict) -> str | None:
+    # TRIR returns featureCode; the default backend returns deviceFeatureCode.
+    return appliance.get("deviceFeatureCode") or appliance.get("featureCode")
 
 
 async def main(api: ConnectLifeApi, format: str):
@@ -29,17 +32,53 @@ async def main(api: ConnectLifeApi, format: str):
         appliance["deviceId"] = "<redacted>"
         appliance["puid"] = "<redacted>"
         appliance["wifiId"] = "<redacted>"
-        if format == "json":
-            with open(f'{appliance["deviceTypeCode"]}-{appliance["deviceFeatureCode"]}.json', 'w') as f:
-                json.dump(order_dict(appliance), f, indent=2)
-        if format == "dd":
-            status_list = appliance.get("statusList", {})
-            with open(f'{appliance["deviceTypeCode"]}-{appliance["deviceFeatureCode"]}.yaml', 'w') as f:
-                f.write(f'# {appliance["deviceNickName"]}\n')
-                f.write('properties:\n')
-                for k, v in sorted(status_list.items()):
-                    f.write(f'- property: {k}\n')
-                    f.write(f'  # Sample value: {v}\n')
+    if format == "json":
+        dump_json(appliances)
+    if format == "dd":
+        dump_data_dictionaries(appliances)
+
+
+def dump_json(appliances):
+    """Write one JSON file per device, preserving the raw payload."""
+    seen: dict[str, int] = {}
+    for appliance in appliances:
+        base = f'{appliance["deviceTypeCode"]}-{feature_code(appliance)}'
+        # Disambiguate multiple devices that share the same type and feature
+        # code so they don't overwrite each other (e.g. several identical ACs).
+        seen[base] = seen.get(base, 0) + 1
+        name = base if seen[base] == 1 else f'{base}_{seen[base]}'
+        filename = f'{name}.json'
+        with open(filename, 'w') as f:
+            json.dump(order_dict(appliance), f, indent=2)
+        print(f'Wrote {filename}')
+
+
+def dump_data_dictionaries(appliances):
+    """Write one data dictionary skeleton per type/feature code.
+
+    Devices that share a type/feature code are merged so the skeleton lists
+    every distinct value observed for each property across all of them.
+    """
+    groups: dict[str, dict] = {}
+    for appliance in appliances:
+        base = f'{appliance["deviceTypeCode"]}-{feature_code(appliance)}'
+        group = groups.setdefault(base, {"nicknames": [], "values": {}})
+        group["nicknames"].append(appliance["deviceNickName"])
+        for k, v in appliance.get("statusList", {}).items():
+            observed = group["values"].setdefault(k, [])
+            if v not in observed:
+                observed.append(v)
+    for base, group in groups.items():
+        filename = f'{base}.yaml'
+        with open(filename, 'w') as f:
+            f.write(f'# {", ".join(group["nicknames"])}\n')
+            f.write('properties:\n')
+            for k in sorted(group["values"]):
+                values = group["values"][k]
+                label = "Observed value" if len(values) == 1 else "Observed values"
+                f.write(f'- property: {k}\n')
+                f.write(f'  # {label}: {", ".join(values)}\n')
+        print(f'Wrote {filename}')
 
 
 if __name__ == "__main__":
@@ -65,16 +104,6 @@ if __name__ == "__main__":
         action="store_true",
         help="Use the TRIR (Russia/CIS) backend instead of the default",
     )
-    parser.add_argument(
-        "--device-uuid",
-        help="TRIR only: stable device UUID (generated if omitted)",
-    )
-    parser.add_argument(
-        "--platform",
-        choices=["android", "ios"],
-        default="android",
-        help="TRIR only: app platform to emulate (default: android)",
-    )
     parser.add_argument("-v", "--verbose", action='store_true')
     args = parser.parse_args()
     username = args.username if args.username else input("Username: ")
@@ -88,5 +117,5 @@ if __name__ == "__main__":
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-    api = build_api(username, password, args.trir, args.device_uuid, args.platform)
+    api = build_api(username, password, args.trir)
     asyncio.run(main(api, args.format))

--- a/connectlife/test_server.py
+++ b/connectlife/test_server.py
@@ -237,7 +237,13 @@ def main(args):
             appliance = json.load(f)
             appliance["deviceId"] = filename[0:-5]
             appliance["puid"] = f"puid{appliance['deviceId']}"
-            appliance["deviceNickName"] = f'{appliance["deviceNickName"]} ({appliance["deviceTypeCode"]}-{appliance["deviceFeatureCode"]})'
+            # Expose both feature code fields so a single running server can
+            # serve EU (deviceFeatureCode) and TRIR (featureCode) clients,
+            # regardless of which dump format the base file uses.
+            feature = appliance.get("deviceFeatureCode") or appliance.get("featureCode")
+            appliance["deviceFeatureCode"] = feature
+            appliance["featureCode"] = feature
+            appliance["deviceNickName"] = f'{appliance["deviceNickName"]} ({appliance["deviceTypeCode"]}-{feature})'
             appliances[appliance["puid"]] = appliance
 
     app = web.Application()

--- a/connectlife/test_server.py
+++ b/connectlife/test_server.py
@@ -1,4 +1,6 @@
 import asyncio
+import base64
+import hashlib
 from random import randrange
 
 from aiohttp import web
@@ -6,6 +8,17 @@ import argparse
 import json
 from os import listdir
 from os.path import isfile, join
+
+from cryptography.hazmat.primitives import padding as sym_padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from connectlife.trir import (
+    TRIR_AES_IV,
+    TRIR_AES_KEY,
+    TRIR_APPS,
+    TRIR_TRANSPORT_MAGIC,
+    TRIR_VENDOR_SECRET,
+)
 
 appliances = {}
 failure_rate = 0
@@ -104,6 +117,118 @@ async def air_duct_energy(request):
         return _gateway_error(404, f"Unknown puid {puid}")
     return _gateway_ok({"resultData": {"electricTotal": 0.0, "durationTotal": 0}})
 
+# -- TRIR (Russia/CIS) backend ---------------------------------------------
+
+# Canned tokens returned by the TRIR login/refresh endpoints. The *ExpiredTime
+# fields are lifetimes in seconds, matching the real gateway.
+TRIR_TOKENS = {
+    "customerId": "12345678901234567",
+    "accessToken": "trir_access_token",
+    "accessTokenCreateTime": 0,
+    "accessTokenExpiredTime": 86400,
+    "refreshToken": "trir_refresh_token",
+    "refreshTokenExpiredTime": 2592000,
+}
+
+
+def _trir_ok(data=None):
+    """Return a successful TRIR gateway response envelope."""
+    response = {"resultCode": 0, "errorCode": 0, "errorDesc": None}
+    if data is not None:
+        response.update(data)
+    return web.Response(
+        content_type="application/json",
+        text=json.dumps({"response": response, "signatureServer": "test"}),
+    )
+
+
+def _trir_error(error_code, error_desc):
+    """Return a TRIR error response envelope."""
+    return web.Response(
+        content_type="application/json",
+        text=json.dumps({"response": {
+            "resultCode": 1,
+            "errorCode": error_code,
+            "errorDesc": error_desc,
+        }, "signatureServer": "test"}),
+    )
+
+
+def _trir_decode_body(body: str) -> dict:
+    """Decode a TRIR request body (HENC-wrapped or plain JSON) to a dict."""
+    if body.startswith(TRIR_TRANSPORT_MAGIC):
+        ciphertext = base64.b64decode(body[len(TRIR_TRANSPORT_MAGIC):])
+        decryptor = Cipher(algorithms.AES(TRIR_AES_KEY), modes.CBC(TRIR_AES_IV)).decryptor()
+        padded = decryptor.update(ciphertext) + decryptor.finalize()
+        unpadder = sym_padding.PKCS7(128).unpadder()
+        body = (unpadder.update(padded) + unpadder.finalize()).decode()
+    return json.loads(body)
+
+
+def _trir_app_secret(app_id):
+    for app in TRIR_APPS.values():
+        if app["app_id"] == app_id:
+            return app["app_secret"]
+    return None
+
+
+def _trir_expected_sign(data: dict, app_secret: str) -> str:
+    items = []
+    for key in sorted(k for k in data if k != "sign"):
+        value = data[key]
+        if not value:
+            continue
+        if isinstance(value, (dict, list)):
+            value = json.dumps(value, separators=(",", ":"))
+        items.append(f"{key}={value}")
+    sign_str = f"{app_secret}{'&'.join(items)}{TRIR_VENDOR_SECRET}"
+    return hashlib.sha1(sign_str.encode()).hexdigest()
+
+
+def _trir_verify(data: dict):
+    """Return an error Response if the request is malformed, else None."""
+    app_secret = _trir_app_secret(data.get("appId"))
+    if app_secret is None:
+        return _trir_error(600902, f"Unknown appId {data.get('appId')}")
+    if data.get("sign") != _trir_expected_sign(data, app_secret):
+        return _trir_error(600903, "Signature mismatch")
+    return None
+
+
+async def trir_login(request):
+    try:
+        data = _trir_decode_body(await request.text())
+    except Exception as err:  # noqa: BLE001
+        return _trir_error(600901, f"Unable to decode request body: {err}")
+    if auth_error_rate > randrange(100):
+        return _trir_error(600904, "User name or password error")
+    if (error := _trir_verify(data)) is not None:
+        return error
+    return _trir_ok(TRIR_TOKENS)
+
+
+async def trir_refresh_token(request):
+    data = _trir_decode_body(await request.text())
+    if (error := _trir_verify(data)) is not None:
+        return error
+    return _trir_ok(TRIR_TOKENS)
+
+
+async def trir_device_tab_list(request):  # noqa: ARG001
+    if failure_rate > randrange(100):
+        return web.Response(status=500)
+    if timeout_rate > randrange(100):
+        await asyncio.sleep(10.1)
+    return _trir_ok({
+        "deviceList": list(appliances.values()),
+        "tabCardList": [],
+        "roomList": [],
+        "floorList": [],
+        "locationList": None,
+        "ext": {},
+    })
+
+
 def main(args):
     directory = args.directory
     filenames = list(filter(lambda f: f[-5:] == ".json", [f for f in listdir(directory) if isfile(join(directory, f))]))
@@ -123,6 +248,10 @@ def main(args):
     app.add_routes([web.get('/clife-svc/pu/get_device_status_list', get_device_status_list)])
     app.add_routes([web.post('/device/pu/property/set', property_set)])
     app.add_routes([web.post('/clife-svc/pu/air_duct_energy', air_duct_energy)])
+    # TRIR (Russia/CIS) backend. property/set and air_duct_energy are shared.
+    app.add_routes([web.post('/account/acc/login_pwd', trir_login)])
+    app.add_routes([web.post('/account/acc/refresh_token', trir_refresh_token)])
+    app.add_routes([web.post('/br/getDeviceTabList', trir_device_tab_list)])
     web.run_app(app, port=args.port)
 
 if __name__ == '__main__':

--- a/connectlife/trir.py
+++ b/connectlife/trir.py
@@ -85,11 +85,9 @@ TRIR_PASSWORD_PUBLIC_KEY = cast(
 TRIR_DEFAULT_TOKEN_LIFETIME = 7200
 TRIR_TOKEN_RENEW_MARGIN = 90
 
-# TODO(#267): confirm the gateway error codes TRIR uses. The EU values are a
-# reasonable starting guess given the shared infrastructure; if wrong, the only
-# effect is that the in-request reauth/randStr retry won't fire and the next
-# poll re-logs in instead.
+# Invalid/expired access token; confirmed against the live TRIR gateway.
 TRIR_INVALID_ACCESS_TOKEN = 100026
+# randStr check failure; inherited from the EU gateway value.
 TRIR_RANDSTR_CHECK_FAILED = 101005
 
 
@@ -222,7 +220,14 @@ class TrirConnectLifeApi(ConnectLifeApi):
                 "Unexpected response from TRIR gateway: missing 'deviceList'",
                 endpoint=self.gateway_device_list_url,
             )
-        return [self._normalize_trir_device(d) for d in device_list]
+        # Returned raw (not mapped onto the EU schema) so dumps record the
+        # actual TRIR payload; mapping happens in _normalize_appliance_payloads.
+        return device_list
+
+    def _normalize_appliance_payloads(self, payloads: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Map TRIR device payloads onto the EU schema before building appliances."""
+        payloads = [self._normalize_trir_device(p) for p in payloads]
+        return super()._normalize_appliance_payloads(payloads)
 
     @classmethod
     def _normalize_trir_device(cls, device: dict[str, Any]) -> dict[str, Any]:

--- a/connectlife/trir.py
+++ b/connectlife/trir.py
@@ -1,0 +1,337 @@
+"""ConnectLife.TRIR API client.
+
+TRIR is the Hisense ConnectLife variant used in Russia/CIS. It runs on the same
+HijuConn gateway infrastructure as the EU service (same host family, same vendor
+secret, same `/device/pu/property/set` and `/clife-svc/pu/air_duct_energy`
+endpoints, same `statusList` schema), but differs in three ways:
+
+1. Auth: a single `/account/acc/login_pwd` POST (AES-CBC "HENC-" transport
+   envelope + RSA-encrypted password) instead of the Gigya/OAuth2 chain.
+2. Request signing: ``SHA1(app_secret + sorted_items + vendor_secret)`` instead
+   of the EU ``RSA(SHA256(sorted_items + suffix))``. TRIR also drops falsy
+   fields from the signed string.
+3. Device list: ``POST /br/getDeviceTabList`` (the EU
+   ``/clife-svc/pu/get_device_status_list`` returns 405 on the RU gateway). The
+   per-device payload uses slightly different field names that we normalize back
+   onto the EU ``ConnectLifeAppliance`` schema.
+
+Token lifecycle (refresh + re-login fallback) is inherited unchanged from
+``ConnectLifeApi._fetch_access_token``: we only override how the initial login
+and the refresh are performed. If refresh fails for any reason, the base class
+already resets tokens and performs a full re-login, so refresh is effectively
+optional — TRIR login is a single cheap request.
+
+Reverse engineering by @vit9696, https://github.com/oyvindwe/connectlife-ha/issues/267.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import hashlib
+import json
+import logging
+import secrets
+import uuid
+from typing import Any, cast
+
+from cryptography.hazmat.primitives import padding as sym_padding
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from .api import ConnectLifeApi, LifeConnectAuthError, LifeConnectError
+
+_LOGGER = logging.getLogger(__name__)
+
+TRIR_BASE_URL = "https://clife-ru2-gateway.hijuconn.com"
+
+# Shared with the EU gateway (== GATEWAY_SIGN_SUFFIX in api.py).
+TRIR_VENDOR_SECRET = "D9519A4B756946F081B7BB5B5E8D1197"
+
+# Per-platform application identities extracted from the mobile apps.
+TRIR_APPS = {
+    "android": {
+        "app_id": "17930742094888975",
+        "app_secret": "uyIr_SJpd6-aL-yTMq50idPbmeL3LXs6vOExhXy_LuhqaIHZGz46nI9BYlWQPel0",
+        "client_id": "td0010010000",
+    },
+    "ios": {
+        "app_id": "17930742096986127",
+        "app_secret": "j4FmB-xO2bfiTiM7hoVBp8_ADxH49Nb9TVX_UGUx1qMbUwVGN3Nq47hPt5IH3NuK",
+        "client_id": "td0010020000",
+    },
+}
+
+# AES-256-CBC transport obfuscation for the login request body. The key/IV are
+# hardcoded in the app; the magic prefix marks an encrypted payload.
+TRIR_TRANSPORT_MAGIC = "HENC-"
+TRIR_AES_KEY = b"aaaabbbbccccddddeeeeffffgggghhhh"
+TRIR_AES_IV = b"aaaabbbbccccdddd"
+
+# RSA public key used to wrap the (MD5-hashed, upper-hex) password.
+TRIR_PASSWORD_PUBLIC_KEY = cast(
+    RSAPublicKey,
+    serialization.load_pem_public_key(
+        b"-----BEGIN PUBLIC KEY-----\n"
+        b"MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAL1pyw5RThDowxOMDeV/p5vY3f8o5hgt\n"
+        b"hurwD9Ybby5OVQl3gyHLPie4j6HVmDCMypWbGt94LvpYtVW3ZDVIAc0CAwEAAQ==\n"
+        b"-----END PUBLIC KEY-----\n"
+    ),
+)
+
+# Fallback token lifetime if the server omits accessTokenExpiredTime.
+TRIR_DEFAULT_TOKEN_LIFETIME = 7200
+TRIR_TOKEN_RENEW_MARGIN = 90
+
+# TODO(#267): confirm the gateway error codes TRIR uses. The EU values are a
+# reasonable starting guess given the shared infrastructure; if wrong, the only
+# effect is that the in-request reauth/randStr retry won't fire and the next
+# poll re-logs in instead.
+TRIR_INVALID_ACCESS_TOKEN = 100026
+TRIR_RANDSTR_CHECK_FAILED = 101005
+
+
+class TrirConnectLifeApi(ConnectLifeApi):
+    """ConnectLife API client for the Russia/CIS (TRIR) backend."""
+
+    # The captured client identifies as a Flutter/Dart app; mirror it in case
+    # the gateway is picky about the User-Agent.
+    gateway_user_agent = "Dart/3.8 (dart:io)"
+    invalid_access_token_code = TRIR_INVALID_ACCESS_TOKEN
+    randstr_check_failed_code = TRIR_RANDSTR_CHECK_FAILED
+
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        test_server: str | None = None,
+        *,
+        device_uuid: str | None = None,
+        platform: str = "android",
+        language_id: str = "1",
+        timezone: str = "Europe/Moscow",
+        version: str = "8.1",
+    ):
+        """Initialize the TRIR client.
+
+        device_uuid should be stable across restarts (the integration ought to
+        generate one and persist it in the config entry), because the derived
+        ``sourceId`` ties the session to a "device". A fresh UUID each start
+        likely still works but registers a new pseudo-device every time.
+        """
+        super().__init__(username, password)
+
+        app = TRIR_APPS[platform]
+        self.app_id = app["app_id"]
+        self.app_secret = app["app_secret"]
+        self.client_id = app["client_id"]
+        self.vendor_secret = TRIR_VENDOR_SECRET
+
+        self.language_id = language_id
+        self.timezone = timezone
+        self.version = version
+
+        raw_uuid = uuid.UUID(device_uuid) if device_uuid else uuid.uuid4()
+        device_id = hashlib.md5(raw_uuid.bytes.hex().encode()).hexdigest()
+        self.source_id = f"{self.client_id}{device_id}"
+
+        base = test_server or TRIR_BASE_URL
+        self.login_url = f"{base}/account/acc/login_pwd"
+        self.refresh_url = f"{base}/account/acc/refresh_token"
+        self.gateway_device_list_url = f"{base}/br/getDeviceTabList"
+        self.gateway_update_url = f"{base}/device/pu/property/set"
+        self.gateway_energy_url = f"{base}/clife-svc/pu/air_duct_energy"
+
+    # -- Auth: initial login -------------------------------------------------
+
+    async def _initial_access_token(self) -> None:
+        request_data = self._trir_base_payload()
+        request_data["accessToken"] = None
+        request_data["loginName"] = self._username
+        request_data["password"] = self._encode_password(self._password)
+        request_data["sign"] = self._sign_gateway_request(request_data)
+
+        body = json.dumps(request_data, separators=(",", ":"))
+        envelope = await self._trir_post(self.login_url, self._encrypt_transport(body))
+        self._set_trir_token_state(envelope)
+
+    # -- Auth: refresh (falls back to re-login via base _fetch_access_token) --
+
+    async def _refresh_access_token(self) -> None:
+        request_data = self._trir_base_payload()
+        # The current (expired) access token is still sent alongside the refresh
+        # token, matching the app's behavior.
+        request_data["accessToken"] = self._access_token
+        request_data["refreshToken"] = self._refresh_token
+        request_data["sign"] = self._sign_gateway_request(request_data)
+
+        # The refresh request is plain JSON (not HENC-wrapped).
+        body = json.dumps(request_data, separators=(",", ":"))
+        envelope = await self._trir_post(self.refresh_url, body)
+        self._set_trir_token_state(envelope)
+
+    def _set_trir_token_state(self, response: dict[str, Any]) -> None:
+        """Validate a login/refresh reply and store the resulting tokens.
+
+        Raises LifeConnectAuthError on failure so the base class falls back to a
+        full re-login.
+        """
+        result_code = response.get("resultCode")
+        if result_code not in (0, "0"):
+            error_code = response.get("errorCode")
+            error_desc = response.get("errorDesc") or "Unknown TRIR auth error"
+            raise LifeConnectAuthError(
+                f"TRIR auth failed: code={error_code} description='{error_desc}'"
+            )
+
+        self._access_token = self._require_auth_field(response, "accessToken")
+        self._refresh_token = response.get("refreshToken", self._refresh_token)
+
+        now = dt.datetime.now()
+        # *ExpiredTime fields are lifetimes in seconds (not absolute). Compute
+        # from "now" to avoid depending on the server clock. TODO(#267): verify.
+        access_lifetime = (
+            self._int_or_default(response.get("accessTokenExpiredTime"), None)
+            or TRIR_DEFAULT_TOKEN_LIFETIME
+        )
+        self._expires = now + dt.timedelta(
+            seconds=access_lifetime - TRIR_TOKEN_RENEW_MARGIN
+        )
+        refresh_lifetime = self._int_or_default(response.get("refreshTokenExpiredTime"), 0) or 0
+        self._refresh_token_expires = (
+            now + dt.timedelta(seconds=refresh_lifetime) if refresh_lifetime else None
+        )
+
+    # -- Device list ---------------------------------------------------------
+
+    async def _request_gateway_appliances_json(
+        self, *, retry_on_reauth: bool
+    ) -> list[dict[str, Any]]:
+        gateway_response = await self._request_gateway_json(
+            self.gateway_device_list_url,
+            payload={"dataType": "0"},
+            retry_on_reauth=retry_on_reauth,
+            retry_on_randstr=True,
+            method="POST",
+        )
+        device_list = gateway_response.get("deviceList")
+        if not isinstance(device_list, list):
+            raise LifeConnectError(
+                "Unexpected response from TRIR gateway: missing 'deviceList'",
+                endpoint=self.gateway_device_list_url,
+            )
+        return [self._normalize_trir_device(d) for d in device_list]
+
+    @classmethod
+    def _normalize_trir_device(cls, device: dict[str, Any]) -> dict[str, Any]:
+        """Map a TRIR getDeviceTabList entry onto the EU appliance schema."""
+        d = dict(device)
+        # Field renames.
+        d.setdefault("deviceFeatureCode", d.get("featureCode", None))
+        # Fields TRIR omits that ConnectLifeAppliance reads unconditionally.
+        d.setdefault("deviceFeatureName", None)
+        d.setdefault("deviceTypeName", None)
+        d.setdefault("seq", 0)
+        # Timestamps arrive as strings (and bindTime is named bindDate); the
+        # appliance model does `value / 1000`, so they must be ints or falsy.
+        d["bindTime"] = cls._int_or_default(d.get("bindTime", d.get("bindDate")), None)
+        d["useTime"] = cls._int_or_default(d.get("useTime"), None)
+        d["createTime"] = cls._int_or_default(d.get("createTime"), None)
+        return d
+
+    # -- Gateway request building / signing (overrides EU implementations) ----
+
+    def _gateway_request_data(self, payload: dict[str, Any]) -> dict[str, Any]:
+        request_data = self._trir_base_payload()
+        request_data["accessToken"] = self._require_access_token()
+        request_data.update(payload)
+        request_data["sign"] = self._sign_gateway_request(request_data)
+        return request_data
+
+    def _trir_base_payload(self) -> dict[str, Any]:
+        return {
+            "timeStamp": str(int(dt.datetime.now().timestamp() * 1000)),
+            "version": self.version,
+            "languageId": self.language_id,
+            "timezone": self.timezone,
+            "randStr": secrets.token_hex(16),
+            "appId": self.app_id,
+            "sourceId": self.source_id,
+        }
+
+    def _sign_gateway_request(self, payload: dict[str, Any]) -> str:  # type: ignore[override]
+        items = []
+        for key in sorted(k for k in payload if k != "sign"):
+            value = payload[key]
+            if not value:  # TRIR drops falsy fields (incl. accessToken=None).
+                continue
+            if isinstance(value, (dict, list)):
+                value = json.dumps(value, separators=(",", ":"))
+            items.append(f"{key}={value}")
+        sign_str = f"{self.app_secret}{'&'.join(items)}{self.vendor_secret}"
+        return hashlib.sha1(sign_str.encode()).hexdigest()
+
+    # -- Crypto helpers ------------------------------------------------------
+
+    def _encode_password(self, password: str) -> str:
+        digest = hashlib.md5(password.encode()).hexdigest().upper().encode()
+        encrypted = TRIR_PASSWORD_PUBLIC_KEY.encrypt(digest, padding.PKCS1v15())
+        return base64.b64encode(encrypted).decode()
+
+    @staticmethod
+    def _encrypt_transport(plaintext: str) -> str:
+        padder = sym_padding.PKCS7(128).padder()  # AES block size in bits
+        padded = padder.update(plaintext.encode()) + padder.finalize()
+        encryptor = Cipher(algorithms.AES(TRIR_AES_KEY), modes.CBC(TRIR_AES_IV)).encryptor()
+        ciphertext = encryptor.update(padded) + encryptor.finalize()
+        return f"{TRIR_TRANSPORT_MAGIC}{base64.b64encode(ciphertext).decode()}"
+
+    # -- HTTP ----------------------------------------------------------------
+
+    async def _trir_post(self, url: str, body: str) -> dict[str, Any]:
+        """POST a raw (already-serialized/encrypted) body and unwrap the reply.
+
+        TRIR wraps every reply as ``{"response": {...}, "signatureServer": ...}``;
+        we return the inner ``response`` object.
+        """
+        async with self._client_session() as session:
+            async with session.post(
+                url,
+                data=body,
+                headers={
+                    "User-Agent": self.gateway_user_agent,
+                    "Content-Type": "application/json; charset=utf-8",
+                    "Accept-Encoding": "gzip",
+                },
+            ) as response:
+                if response.status != 200:
+                    text = await self._read_response_body(response)
+                    raise self._response_error(
+                        "Unexpected response from TRIR endpoint: status={status}",
+                        response,
+                        text,
+                        endpoint=url,
+                        auth=True,
+                    )
+                envelope = await self._json(response, endpoint=url, auth=True)
+
+        inner = envelope.get("response") if isinstance(envelope, dict) else None
+        if not isinstance(inner, dict):
+            raise LifeConnectAuthError(
+                "Unexpected response from TRIR endpoint: missing 'response'",
+                endpoint=url,
+            )
+        return inner
+
+    # -- Misc ----------------------------------------------------------------
+
+    @staticmethod
+    def _int_or_default(value: Any, default: int | None) -> int | None:
+        if value in (None, "", "null"):
+            return default
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default


### PR DESCRIPTION
TRIR is the Hisense ConnectLife variant for Russia/CIS. It runs on the same HijuConn gateway as the EU service (shared host family, vendor secret, property-set and energy endpoints, and `statusList` schema) but authenticates differently and uses a separate device-list endpoint.

> [!WARNING]
> **Experimental.** Login, device listing, and energy are confirmed against a live server, along with the invalid-access-token gateway code. Still unverified by a TRIR user: the token-refresh success path and expiry semantics, the randStr error code, and write-back (set property). Expect rough edges until then.

## What this adds

`TrirConnectLifeApi`, a subclass of `ConnectLifeApi` that overrides only what differs:

- **Auth**: a single `/account/acc/login_pwd` POST (AES-CBC `HENC-` transport envelope + RSA-wrapped password) instead of the Gigya/OAuth2 chain.
- **Signing**: `SHA1(app_secret + sorted_items + vendor_secret)`, dropping falsy fields, instead of the EU `RSA(SHA256(...))`.
- **Device list**: `POST /br/getDeviceTabList` (the EU status-list endpoint returns 405 on the RU gateway). The raw payload is preserved; during appliance construction it is mapped onto the existing schema (`featureCode` → `deviceFeatureCode`, `bindDate` → `bindTime`, string timestamps → ints, defaults for omitted fields).

The token lifecycle is inherited unchanged: refresh is attempted via `/account/acc/refresh_token` and, on any failure, the base class falls back to a full re-login. To let the subclass reuse the gateway request/retry plumbing, the gateway user-agent and the reauth/randStr error codes become overridable class attributes (behavior-preserving for the EU client).

## Tooling

- **dump**: `-t/--trir` dumps appliances via the TRIR backend. JSON dumps preserve the raw payload, one file per device (same-model devices get a numeric suffix, e.g. `009-109_2.json`); `dd` merges devices that share a type/feature code into one skeleton listing every observed value per property.
- **test_server**: serves the three TRIR routes (`login_pwd`, `refresh_token`, `getDeviceTabList`); property-set and energy are shared, and every device exposes both feature-code fields so one instance serves EU and TRIR clients without a restart. The login/refresh handlers decrypt the HENC body and recompute the SHA-1 signature, so the test server is a conformance check for the client's transport and signing rather than rubber-stamping requests.

Reverse engineering by @vit9696, see oyvindwe/connectlife-ha#267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
