### PR TITLE
Add capability-probe queries and split dump CLI into --query/--format

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ use `--query static`:
 python -m connectlife.dump --username <username> --password <password> --query static
 ```
 Because it's keyed by the device's puid, the response can differ between two physical models that
-report the same device type/feature code. The responses are gateway-defined and may contain
-identifiers — review each file before sharing. (For the per-feature-code property list, use
+report the same device type/feature code. The response echoes the puid, so the dump redacts the
+puid, wifi_id and device_id — but the schema is gateway-defined and may contain other identifiers,
+so review each file before sharing. (For the per-feature-code property list, use
 `--query property-list` below.)
 
 To fetch the property list for a specific device type and feature code (any code, not just ones on

--- a/README.md
+++ b/README.md
@@ -20,12 +20,36 @@ python -m connectlife.dump --username <username> --password <password> [--trir]
 ```
 
 This will log in to the ConnectLife API using the provided username and password, and write a JSON
-file with all returned fields for each appliance that is registered with the account.
+file with all returned fields for each appliance that is registered with the account. Pass
+`--format dd` to instead write a mapping file YAML skeleton to be used with
+[connectlife-ha](https://github.com/oyvindwe/connectlife-ha).
+
+> **Note:** the property set a device reports is not authoritative. A device may report properties it
+> does not actually support (and may omit ones its feature code defines), so two units with the same
+> device type/feature code can report different properties. Treat dumps as a starting point for a
+> mapping, not ground truth — cross-check controls against the device or the ConnectLife app.
 
 To instead dump each appliance's energy statistics (both the `air_duct_energy` and
-`energyConsumptionCurve` endpoints), add `--format energy`:
+`energyConsumptionCurve` endpoints), use `--query energy`:
 ```bash
-python -m connectlife.dump --username <username> --password <password> --format energy
+python -m connectlife.dump --username <username> --password <password> --query energy
+```
+
+To dump each appliance's per-device static data (the `query_static_data` endpoint, keyed by puid),
+use `--query static`:
+```bash
+python -m connectlife.dump --username <username> --password <password> --query static
+```
+Because it's keyed by the device's puid, the response can differ between two physical models that
+report the same device type/feature code. The responses are gateway-defined and may contain
+identifiers — review each file before sharing. (For the per-feature-code property list, use
+`--query property-list` below.)
+
+To fetch the property list for a specific device type and feature code (any code, not just ones on
+your account), use `--query property-list`:
+```bash
+python -m connectlife.dump --username <username> --password <password> \
+    --query property-list --device-type-code <type-code> --device-feature-code <feature-code>
 ```
 
 The Home Assistant integration is currently in discovery phase. Please contribute your device dumps to help

--- a/connectlife/api.py
+++ b/connectlife/api.py
@@ -38,6 +38,10 @@ GATEWAY_DEVICE_LIST_URL = f"{GATEWAY_BASE_URL}/clife-svc/pu/get_device_status_li
 GATEWAY_UPDATE_URL = f"{GATEWAY_BASE_URL}/device/pu/property/set"
 GATEWAY_ENERGY_URL = f"{GATEWAY_BASE_URL}/clife-svc/pu/air_duct_energy"
 GATEWAY_ENERGY_CONSUMPTION_URL = f"{GATEWAY_BASE_URL}/clife-svc/pu/energyConsumptionCurve"
+# Per-device static data (keyed by puid) and per-feature-code property list.
+# Exploratory: these power capability probing, not the normal poll cycle.
+GATEWAY_STATIC_DATA_URL = f"{GATEWAY_BASE_URL}/clife-svc/pu/query_static_data"
+GATEWAY_PROPERTY_LIST_URL = f"{GATEWAY_BASE_URL}/clife-svc/get_property_list"
 GATEWAY_APP_ID = "47110565134383"
 GATEWAY_APP_SECRET = "yOzhz6junYno-nmULM3Wr7PU_dpSZN22ZdluvVWZ4uW5ZwwG8fIGCHTbrhcnU-iv"
 GATEWAY_LANGUAGE_ID = "12"
@@ -210,6 +214,8 @@ class ConnectLifeApi:
     gateway_update_url = GATEWAY_UPDATE_URL
     gateway_energy_url = GATEWAY_ENERGY_URL
     gateway_energy_consumption_url = GATEWAY_ENERGY_CONSUMPTION_URL
+    gateway_static_data_url = GATEWAY_STATIC_DATA_URL
+    gateway_property_list_url = GATEWAY_PROPERTY_LIST_URL
 
     # Overridable so alternative backends (e.g. TRIR) can vary the client
     # identity and the gateway error codes they react to.
@@ -234,6 +240,8 @@ class ConnectLifeApi:
             self.gateway_update_url = f"{test_server}/device/pu/property/set"
             self.gateway_energy_url = f"{test_server}/clife-svc/pu/air_duct_energy"
             self.gateway_energy_consumption_url = f"{test_server}/clife-svc/pu/energyConsumptionCurve"
+            self.gateway_static_data_url = f"{test_server}/clife-svc/pu/query_static_data"
+            self.gateway_property_list_url = f"{test_server}/clife-svc/get_property_list"
 
         self._username = username
         self._password = password
@@ -345,6 +353,44 @@ class ConnectLifeApi:
         if data is None:
             return None
         return EnergyConsumption._from_result_data(stat_type, date_start, date_end, data)
+
+    async def query_static_data(self, puid: str) -> dict[str, Any]:
+        """Probe the per-device static data endpoint (``query_static_data``).
+
+        Keyed by ``puid``, so — unlike :meth:`get_property_list` — it can return
+        different data for two devices that share a type/feature code. The
+        response schema is gateway-defined and undocumented; this returns the raw
+        ``response`` object for inspection. Raises :class:`LifeConnectError` for
+        devices/firmware that don't support it (the error is itself informative).
+        """
+        await self._fetch_access_token()
+        return await self._request_gateway_json(
+            self.gateway_static_data_url,
+            payload={"puid": puid},
+            retry_on_reauth=True,
+            retry_on_randstr=True,
+        )
+
+    async def get_property_list(
+        self, device_type_code: str, device_feature_code: str
+    ) -> dict[str, Any]:
+        """Probe the per-feature-code property list endpoint (``get_property_list``).
+
+        Keyed by type/feature code, so it returns the *same* list for every
+        device with that code — it cannot distinguish variants that share one.
+        Returns the raw ``response`` object; schema is gateway-defined.
+        """
+        await self._fetch_access_token()
+        return await self._request_gateway_json(
+            self.gateway_property_list_url,
+            payload={
+                "deviceTypeCode": device_type_code,
+                "deviceFeatureCode": device_feature_code,
+            },
+            retry_on_reauth=True,
+            retry_on_randstr=True,
+            method="GET",
+        )
 
     async def _fetch_energy(
         self,

--- a/connectlife/dump.py
+++ b/connectlife/dump.py
@@ -105,17 +105,20 @@ async def dump_static(api: ConnectLifeApi):
         base = f"{appliance.device_type_code}-{appliance.device_feature_code}"
         seen[base] = seen.get(base, 0) + 1
         name = base if seen[base] == 1 else f"{base}_{seen[base]}"
+        # query_static_data echoes the puid (and carries wifi_id/device_id keys),
+        # so scrub the identifiers we know before writing a shareable file.
+        secrets = {s for s in (appliance.puid, appliance.device_id, appliance.wifi_id) if s}
         result = {
             "deviceTypeCode": appliance.device_type_code,
             "deviceFeatureCode": appliance.device_feature_code,
-            "query_static_data": await _probe(
-                api.query_static_data, appliance.puid
+            "query_static_data": _redact(
+                await _probe(api.query_static_data, appliance.puid), secrets
             ),
         }
         filename = f"{name}-static.json"
         with open(filename, "w") as f:
             json.dump(result, f, indent=2)
-        print(f"Wrote {filename} (review for identifiers before sharing)")
+        print(f"Wrote {filename} (known identifiers redacted; review before sharing)")
 
 
 async def dump_property_list(
@@ -131,6 +134,23 @@ async def dump_property_list(
     with open(filename, "w") as f:
         json.dump(result, f, indent=2)
     print(f"Wrote {filename}")
+
+
+def _redact(value, secrets):
+    """Recursively replace any string equal to a known identifier with a marker.
+
+    ``query_static_data`` echoes the device's puid (and may carry wifi_id /
+    device_id). We can only scrub the identifiers we passed in — the schema is
+    gateway-defined and may contain others — hence the review-before-sharing
+    reminder still stands.
+    """
+    if isinstance(value, dict):
+        return {k: _redact(v, secrets) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact(v, secrets) for v in value]
+    if isinstance(value, str) and value in secrets:
+        return "<redacted>"
+    return value
 
 
 async def _probe(func, *args):

--- a/connectlife/dump.py
+++ b/connectlife/dump.py
@@ -6,7 +6,7 @@ import logging
 import json
 import sys
 
-from .api import ConnectLifeApi
+from .api import ConnectLifeApi, LifeConnectError
 from .trir import TrirConnectLifeApi
 
 
@@ -26,9 +26,26 @@ def feature_code(appliance: dict) -> str | None:
     return appliance.get("deviceFeatureCode") or appliance.get("featureCode")
 
 
-async def main(api: ConnectLifeApi, format: str):
-    if format == "energy":
+async def main(
+    api: ConnectLifeApi,
+    query: str,
+    format: str,
+    device_type_code: str | None = None,
+    device_feature_code: str | None = None,
+):
+    """Dump the ``query`` data. ``format`` (json/dd) applies only to ``appliances``."""
+    if query == "energy":
         await dump_energy(api)
+        return
+    if query == "static":
+        await dump_static(api)
+        return
+    if query == "property-list":
+        if not device_type_code or not device_feature_code:
+            raise SystemExit(
+                "--query property-list requires --device-type-code and --device-feature-code"
+            )
+        await dump_property_list(api, device_type_code, device_feature_code)
         return
     appliances = await api.get_appliances_json()
     # Redact private fields
@@ -70,6 +87,62 @@ async def dump_energy(api: ConnectLifeApi):
         with open(filename, "w") as f:
             json.dump(result, f, indent=2)
         print(f"Wrote {filename}")
+
+
+async def dump_static(api: ConnectLifeApi):
+    """Write one JSON file per device with its ``query_static_data`` response.
+
+    Keyed by puid, so it can differ between two devices that share a type/feature
+    code — useful for working out whether the gateway exposes anything that
+    distinguishes otherwise-identical feature codes. For the per-feature-code
+    property list, use ``dump_property_list`` (``--format property-list``).
+
+    The response schema is undocumented and may echo identifiers — review and
+    redact each file before sharing.
+    """
+    seen: dict[str, int] = {}
+    for appliance in await api.get_appliances():
+        base = f"{appliance.device_type_code}-{appliance.device_feature_code}"
+        seen[base] = seen.get(base, 0) + 1
+        name = base if seen[base] == 1 else f"{base}_{seen[base]}"
+        result = {
+            "deviceTypeCode": appliance.device_type_code,
+            "deviceFeatureCode": appliance.device_feature_code,
+            "query_static_data": await _probe(
+                api.query_static_data, appliance.puid
+            ),
+        }
+        filename = f"{name}-static.json"
+        with open(filename, "w") as f:
+            json.dump(result, f, indent=2)
+        print(f"Wrote {filename} (review for identifiers before sharing)")
+
+
+async def dump_property_list(
+    api: ConnectLifeApi, device_type_code: str, device_feature_code: str
+):
+    """Fetch and write the property list for a single type/feature code.
+
+    Unlike the other formats this targets an arbitrary code rather than the
+    account's appliances, so it can probe feature codes the account doesn't own.
+    """
+    result = await _probe(api.get_property_list, device_type_code, device_feature_code)
+    filename = f"{device_type_code}-{device_feature_code}-property-list.json"
+    with open(filename, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"Wrote {filename}")
+
+
+async def _probe(func, *args):
+    """Call a probe endpoint, capturing a gateway error instead of aborting.
+
+    A device that doesn't support an endpoint returns a gateway error; recording
+    it is as informative as a success, so the dump shows it rather than failing.
+    """
+    try:
+        return await func(*args)
+    except LifeConnectError as err:
+        return {"error": str(err)}
 
 
 def dump_json(appliances):
@@ -124,14 +197,34 @@ if __name__ == "__main__":
     parser.add_argument("-u", "--username")
     parser.add_argument("-p", "--password")
     parser.add_argument(
+        "-q",
+        "--query",
+        choices={
+            "appliances": "The account's appliances (default; honors --format)",
+            "energy": "Both energy endpoints' responses per device",
+            "static": "The per-device query_static_data response per device",
+            "property-list": "The property list for --device-type-code/--device-feature-code",
+        },
+        default="appliances",
+        help="What to dump (default: appliances)",
+    )
+    parser.add_argument(
         "-f",
         "--format",
         choices={
             "json": "Dump to JSON file",
             "dd": "Create data dictionary skeleton",
-            "energy": "Dump both energy endpoints' responses per device",
         },
-        default="json"
+        default="json",
+        help="Output format for --query appliances (ignored for other queries)",
+    )
+    parser.add_argument(
+        "--device-type-code",
+        help="Device type code (required for --query property-list)",
+    )
+    parser.add_argument(
+        "--device-feature-code",
+        help="Device feature code (required for --query property-list)",
     )
     parser.add_argument(
         "-t",
@@ -153,4 +246,6 @@ if __name__ == "__main__":
         logger.addHandler(handler)
 
     api = build_api(username, password, args.trir)
-    asyncio.run(main(api, args.format))
+    asyncio.run(
+        main(api, args.query, args.format, args.device_type_code, args.device_feature_code)
+    )

--- a/connectlife/test_server.py
+++ b/connectlife/test_server.py
@@ -169,6 +169,19 @@ async def energy_consumption_curve(request):
         },
     })
 
+async def query_static_data(request):
+    req = await request.json()
+    puid = req.get("puid")
+    if puid not in appliances:
+        return _gateway_error(404, f"Unknown puid {puid}")
+    # Stub: echo the device's feature code so per-puid responses differ between
+    # devices the way the real gateway's capability data is expected to.
+    appliance = appliances[puid]
+    return _gateway_ok({"data": {"deviceFeatureCode": appliance.get("deviceFeatureCode")}})
+
+async def get_property_list(request):  # noqa: ARG001
+    return _gateway_ok({"properties": []})
+
 # -- TRIR (Russia/CIS) backend ---------------------------------------------
 
 # Canned tokens returned by the TRIR login/refresh endpoints. The *ExpiredTime
@@ -307,6 +320,8 @@ def main(args):
     app.add_routes([web.post('/device/pu/property/set', property_set)])
     app.add_routes([web.post('/clife-svc/pu/air_duct_energy', air_duct_energy)])
     app.add_routes([web.post('/clife-svc/pu/energyConsumptionCurve', energy_consumption_curve)])
+    app.add_routes([web.post('/clife-svc/pu/query_static_data', query_static_data)])
+    app.add_routes([web.get('/clife-svc/get_property_list', get_property_list)])
     # TRIR (Russia/CIS) backend. property/set and air_duct_energy are shared.
     app.add_routes([web.post('/account/acc/login_pwd', trir_login)])
     app.add_routes([web.post('/account/acc/refresh_token', trir_refresh_token)])

--- a/connectlife/test_server.py
+++ b/connectlife/test_server.py
@@ -174,10 +174,17 @@ async def query_static_data(request):
     puid = req.get("puid")
     if puid not in appliances:
         return _gateway_error(404, f"Unknown puid {puid}")
-    # Stub: echo the device's feature code so per-puid responses differ between
-    # devices the way the real gateway's capability data is expected to.
+    # Stub mirrors the real response shape: it echoes the puid (so the dump tool
+    # has something to redact) and nests capability data under "data". The feature
+    # code is echoed there so per-puid responses differ between devices.
     appliance = appliances[puid]
-    return _gateway_ok({"data": {"deviceFeatureCode": appliance.get("deviceFeatureCode")}})
+    return _gateway_ok({
+        "puid": puid,
+        "dev_type": appliance.get("deviceTypeCode"),
+        "wifi_id": None,
+        "device_id": None,
+        "data": {"deviceFeatureCode": appliance.get("deviceFeatureCode")},
+    })
 
 async def get_property_list(request):  # noqa: ARG001
     return _gateway_ok({"properties": []})

--- a/connectlife/tests/test_api.py
+++ b/connectlife/tests/test_api.py
@@ -20,7 +20,9 @@ from connectlife.api import (
     GATEWAY_ENERGY_CONSUMPTION_URL,
     GATEWAY_ENERGY_URL,
     GATEWAY_INVALID_ACCESS_TOKEN,
+    GATEWAY_PROPERTY_LIST_URL,
     GATEWAY_RANDSTR_CHECK_FAILED,
+    GATEWAY_STATIC_DATA_URL,
     GATEWAY_UPDATE_URL,
     LifeConnectAuthError,
     LifeConnectError,
@@ -644,6 +646,59 @@ class TestEnergyConsumption(unittest.IsolatedAsyncioTestCase):
         assert result is not None
         self.assertEqual(result.electric_total, 2.0)
         self.assertFalse(requests)
+
+
+class TestCapabilityProbes(unittest.IsolatedAsyncioTestCase):
+    """query_static_data (per puid) and get_property_list (per feature code)."""
+
+    async def test_query_static_data_returns_raw_response(self) -> None:
+        api = _cached_api()
+        requests: list[tuple[str, str, FakeResponse]] = [
+            (
+                "POST",
+                GATEWAY_STATIC_DATA_URL,
+                FakeResponse(200, {"response": {
+                    "resultCode": 0,
+                    "data": {"f_humidity": "1"},
+                }}),
+            ),
+        ]
+        with patch.object(api_module.aiohttp, "ClientSession", new=FakeClientSessionFactory(requests)):
+            result = await api.query_static_data("puid-1")
+        self.assertEqual(result["data"], {"f_humidity": "1"})
+        self.assertFalse(requests)
+
+    async def test_get_property_list_is_a_get_request(self) -> None:
+        api = _cached_api()
+        requests: list[tuple[str, str, FakeResponse]] = [
+            (
+                "GET",
+                GATEWAY_PROPERTY_LIST_URL,
+                FakeResponse(200, {"response": {
+                    "resultCode": 0,
+                    "properties": ["t_temp", "t_up_down"],
+                }}),
+            ),
+        ]
+        with patch.object(api_module.aiohttp, "ClientSession", new=FakeClientSessionFactory(requests)):
+            result = await api.get_property_list("009", "104")
+        self.assertEqual(result["properties"], ["t_temp", "t_up_down"])
+        self.assertFalse(requests)
+
+    async def test_gateway_error_propagates(self) -> None:
+        api = _cached_api()
+        requests: list[tuple[str, str, FakeResponse]] = [
+            (
+                "POST",
+                GATEWAY_STATIC_DATA_URL,
+                FakeResponse(200, {"response": {
+                    "resultCode": 1, "errorCode": 999, "errorDesc": "not supported",
+                }}),
+            ),
+        ]
+        with patch.object(api_module.aiohttp, "ClientSession", new=FakeClientSessionFactory(requests)):
+            with self.assertRaises(LifeConnectError):
+                await api.query_static_data("puid-1")
 
 
 class TestRandStrRetry(unittest.IsolatedAsyncioTestCase):

--- a/connectlife/tests/test_dump.py
+++ b/connectlife/tests/test_dump.py
@@ -1,0 +1,39 @@
+"""Tests for the dump tool's helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from connectlife.dump import _redact
+
+
+class TestRedact(unittest.TestCase):
+    """The static dump must scrub known identifiers wherever they appear."""
+
+    def test_replaces_known_identifiers_recursively(self) -> None:
+        secrets = {"pu000150000000000007395190001202200023730262", "dev-123"}
+        payload = {
+            "resultCode": 0,
+            "puid": "pu000150000000000007395190001202200023730262",
+            "dev_type": "015",
+            "data": {"Variant_code": "x", "ids": ["dev-123", "keep-me"]},
+        }
+        self.assertEqual(
+            _redact(payload, secrets),
+            {
+                "resultCode": 0,
+                "puid": "<redacted>",
+                "dev_type": "015",
+                "data": {"Variant_code": "x", "ids": ["<redacted>", "keep-me"]},
+            },
+        )
+
+    def test_leaves_non_identifier_values_untouched(self) -> None:
+        self.assertEqual(
+            _redact({"a": "1", "b": [{"c": "2"}]}, {"secret"}),
+            {"a": "1", "b": [{"c": "2"}]},
+        )
+
+    def test_empty_secrets_is_a_noop(self) -> None:
+        payload = {"puid": "pu-123", "data": {"x": "1"}}
+        self.assertEqual(_redact(payload, set()), payload)


### PR DESCRIPTION
## Why

Two physically different models can share a `deviceTypeCode`/`deviceFeatureCode` yet expose different property sets (see oyvindwe/connectlife-ha#590, where two Hisense ACs both report `009-104` but one adds 19 properties incl. a non-canonical `t_swing_angle`). The feature code alone can't tell the variants apart, so this adds probes for the gateway's capability endpoints — and, while touching the dump CLI, fixes its conflation of *what to fetch* with *how to format*.

## What

- **api**: `query_static_data(puid)` — per-device, keyed by puid, so it can differ between devices sharing a feature code; returns the raw gateway response.
- **api**: `get_property_list(type, feature)` — the per-feature-code schema list (authoritative property set for a code).
- **dump**: replace the overloaded `--format` with two axes:
  - `--query {appliances,energy,static,property-list}` selects *what* to dump (default `appliances`).
  - `--format {json,dd}` renders the `appliances` query only.
  - New `property-list` query takes `--device-type-code`/`--device-feature-code` and works for any code, not just ones on the account.
- **test_server**: stub routes for both endpoints.
- **tests**: cover the raw static-data response, the GET property list, and gateway-error propagation.
- **README**: document `--query`/`--format`, and note that a device's reported property set is not authoritative.

## ⚠️ Breaking change

`--format energy` is now `--query energy` (likewise `--format static`). The package is pre-1.0 and `dump` is a discovery tool, so no deprecation aliases were added.

## Notes

- The probe response schema is gateway-defined and may echo identifiers, so the `static` dump prints a review-before-sharing warning.
- Device dumps for #590 are intentionally **not** included here — they'll go in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)