### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "connectlife"
-version = "0.9.1"
+version = "0.10.0"
 authors = [
     { name="Øyvind Matheson Wergeland", email="oyvind@wergeland.org" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ wheels = [
 
 [[package]]
 name = "connectlife"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bump the minor version from 0.9.1 to 0.10.0.

Updates `pyproject.toml` and regenerates `uv.lock` (via `uv lock`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)